### PR TITLE
Demonstrate shallow routing on subdomains/multi-tenant platforms

### DIFF
--- a/pages/_sites/[site]/index.tsx
+++ b/pages/_sites/[site]/index.tsx
@@ -18,6 +18,7 @@ export const getStaticProps = async ({ params }) => {
 
 export default function Site() {
   const router = useRouter()
+  const { query: { site }, pathname } = router
 
   const renderCounter  = useRef(0);
 
@@ -28,10 +29,10 @@ export default function Site() {
       <button onClick={() => {
         router.push(
           {
-            pathname: '/',
-            query: { hello: 'world', site: 'a' }
+            pathname,
+            query: { site, hello: 'world' },
           },
-          undefined,
+          { pathname: '/', query: { hello: 'world' } },
           { shallow: true }
         )
       }}>


### PR DESCRIPTION
> In response to https://github.com/vercel/next.js/issues/45886

- To avoid full page reloads on subdomain shallow routing, `router.push` calls need to utilize the second argument, ["as"](https://nextjs.org/docs/api-reference/next/router#routerpush)


![Kapture 2023-02-14 at 02 21 05](https://user-images.githubusercontent.com/92991945/218666905-cde8de4b-3d6b-4c0b-a705-2f32ff0a7438.gif)
